### PR TITLE
feat: refactor auth state change callback variable

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -6,9 +6,9 @@ export default defineNuxtRouteMiddleware(async () => {
   const auth = getAuth();
 
   const user = auth.currentUser || await new Promise(resolve => {
-    const unsubscribe = auth.onAuthStateChanged(u => {
+    const unsubscribe = auth.onAuthStateChanged(user => {
       unsubscribe();
-      resolve(u);
+      resolve(user);
     });
   });
 


### PR DESCRIPTION
Renamed the callback parameter from 'u' to 'user' in the onAuthStateChanged handler for improved clarity and consistency.